### PR TITLE
Remove final for this class

### DIFF
--- a/src/main/java/org/knowm/yank/Yank.java
+++ b/src/main/java/org/knowm/yank/Yank.java
@@ -41,7 +41,7 @@ import com.zaxxer.hikari.HikariDataSource;
  *
  * @author timmolter
  */
-public final class Yank {
+public class Yank {
 
   private static final YankPoolManager YANK_POOL_MANAGER = YankPoolManager.INSTANCE;
 


### PR DESCRIPTION
This allows to extend this class and override some behaviours. My idea is to create class YankExtended that extends Yank and throws database errors up. Why? I do understand why you hide exceptions from code. But this stops anyone of creating more complex microservices, because if the database is down, I need to know it is down so I can put circuit breakers on the code. So to hide exceptions in all use cases in not definitely the best solution.

And I would remove final keyword, because it is limiting the possibility of others extending your work.